### PR TITLE
~ make links relative

### DIFF
--- a/modules/server/src/main/twirl/es/weso/head.scala.html
+++ b/modules/server/src/main/twirl/es/weso/head.scala.html
@@ -3,18 +3,18 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <title>@title</title>
 
-<link rel="stylesheet" href="/css/bootstrap.min.css">
-<link rel="stylesheet" href="/css/bootstrap-table.min.css">
+<link rel="stylesheet" href="css/bootstrap.min.css">
+<link rel="stylesheet" href="css/bootstrap-table.min.css">
 
     <!--    <script src="js/delete_jquery-3.1.1.min.js"></script> -->
 <script src="/codemirror-5.24.2/lib/codemirror.js"></script>
 
-    <link rel="stylesheet" href="/css/app.css">
+    <link rel="stylesheet" href="css/app.css">
 
-    <link rel="stylesheet" href="/codemirror-5.24.2/lib/codemirror.css">
-    <link rel="stylesheet" href="/codemirror-5.24.2/theme/eclipse.css">
-    <link rel="stylesheet" href="/codemirror-5.24.2/theme/elegant.css">
-    <link rel="stylesheet" href="/codemirror-5.24.2/theme/monokai.css">
+    <link rel="stylesheet" href="codemirror-5.24.2/lib/codemirror.css">
+    <link rel="stylesheet" href="codemirror-5.24.2/theme/eclipse.css">
+    <link rel="stylesheet" href="codemirror-5.24.2/theme/elegant.css">
+    <link rel="stylesheet" href="codemirror-5.24.2/theme/monokai.css">
 
     <!-- some modes -->
     <script src="/codemirror-5.24.2/mode/turtle/turtle.js"></script>
@@ -25,7 +25,7 @@
     <script src="/codemirror-5.24.2/addon/edit/closebrackets.js"></script>
     <script src="/codemirror-5.24.2/addon/edit/matchbrackets.js"></script>
     <script src="/codemirror-5.24.2/addon/display/placeholder.js"></script>
-    <link rel="stylesheet" href="/css/bootstrap.min.css">
+    <link rel="stylesheet" href="css/bootstrap.min.css">
 
 <style type="text/css">
       .CodeMirror {


### PR DESCRIPTION
didn't do this for
./modules/server/target/scala-2.13/classes/static/codemirror-5.24.2/mode/pug/index.html 36:      link(rel='stylesheet', href='/css/bootstrap.min.css')
./modules/server/src/main/resources/static/codemirror-5.24.2/mode/pug/index.html 36:      link(rel='stylesheet', href='/css/bootstrap.min.css')