### PR TITLE
Moved to a size-based rolling policy for logs.

### DIFF
--- a/docs/api-testing-auditing/testing-auditing_logs.md
+++ b/docs/api-testing-auditing/testing-auditing_logs.md
@@ -34,8 +34,9 @@ The logs written to the files:
 - Are located inside a `logs` folder, in the application's execution path. Therefore, make sure you run the app with a
   user with write access and from a location that is writable.
 
-- Follow a [time-based rolling policy](http://logback.qos.ch/manual/appenders.html#TimeBasedRollingPolicy), which
-  implies that logs are rotated and compressed in a periodic basis defined in logback's configuration file.
+- Follow a [size-based rolling policy](http://logback.qos.ch/manual/appenders.html#SizeBasedTriggeringPolicy), which
+  implies that logs are rotated and compressed when they reach a certain file size defined in logback's configuration
+  file.
 
 ### Adding custom functionality
 

--- a/src/main/resources/logback-configurations/logback.groovy
+++ b/src/main/resources/logback-configurations/logback.groovy
@@ -15,6 +15,7 @@ statusListener(NopStatusListener)
  * Folder, relative to the program's execution path, where program logs will be stored
  */
 def LOGS_FOLDER = "logs"
+def LOGS_FILENAME = "rdfshape-api.log"
 /**
  * Name (key) of the system property determining the application verbosity
  */
@@ -24,16 +25,31 @@ def systemPropertyVerbosity = "rdfshape.api.verbosity.level"
 
 /**
  * Rolling file appender. Create several files inside LOGS_FOLDER. Archives and compresses old logs.
- * Store 3 months of logs before rollback (http://logback.qos.ch/manual/appenders.html#TimeBasedRollingPolicy)
+ * Choices are: 
+ * - Store some time of logs before rollback (http://logback.qos.ch/manual/appenders.html#TimeBasedRollingPolicy)
+ * -> Store N compressed log files of size M before rollback (http://logback.qos.ch/manual/appenders.html#SizeBasedTriggeringPolicy)
  */
 appender("ROLLING", RollingFileAppender) {
+    file = "$LOGS_FOLDER/$LOGS_FILENAME"
     encoder(PatternLayoutEncoder) {
         Pattern = "%d %level %thread %mdc %logger - %m%n"
     }
-    rollingPolicy(TimeBasedRollingPolicy) {
-        FileNamePattern = "$LOGS_FOLDER/%d{yyyy/MM}/%d{yyyy-MM-dd, aux}.log"
-        maxHistory = 3
+
+    rollingPolicy(FixedWindowRollingPolicy) {
+        FileNamePattern = "$LOGS_FOLDER/$LOGS_FILENAME.%i.zip"
+        minIndex = 1
+        maxIndex = 15
     }
+    triggeringPolicy(SizeBasedTriggeringPolicy) {
+        maxFileSize = "100MB"
+    }
+
+    /* Example implementation of a time based log rollback
+        rollingPolicy(TimeBasedRollingPolicy) {
+            FileNamePattern = "$LOGS_FOLDER/%d{yyyy/MM}/%d{yyyy-MM-dd, aux}.log"
+            maxHistory = 3
+        }
+    */
 }
 
 /**

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.0.75-SNAPSHOT"
+ThisBuild / version := "0.0.75a-SNAPSHOT"


### PR DESCRIPTION
Using a size-based policy we can prevent log files from taking up too much disk space.