### PR TITLE
MVP for streaming validations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -293,7 +293,7 @@ lazy val catsVersion   = "2.7.0"
 lazy val cometVersion  = "0.1.7"
 /* ------------------------------------------------------------------------- */
 lazy val mongodbVersion      = "4.6.0"
-lazy val mongo4catsVersion   = "0.4.7"
+lazy val mongo4catsVersion   = "0.4.8"
 lazy val any23Version        = "2.7"
 lazy val rdf4jVersion        = "4.0.0"
 lazy val graphvizJavaVersion = "0.18.1"

--- a/docs/api-usage/streaming.md
+++ b/docs/api-usage/streaming.md
@@ -78,6 +78,9 @@ the validation should be performed, including:
         - _port_ (Optional): Port from which the Kafka server is streaming data.
           Default: `9092`.
         - _topic_: Topic on which the Kafka server is streaming data.
+        - _groupId_ (Optional): Group that the Kafka consumer shall identify
+          with. Useful to resume validations where they left off. Default:
+          string with the name of the app: (`appName-appVersion`).
 
 ```json title="Example client message requesting a streaming validation"
 {
@@ -92,7 +95,7 @@ the validation should be performed, including:
         "source": "byText"
       },
       "triggerMode": {
-        "shapeMap": {
+        "shape-map": {
           "content": "ex:reading@ex:ValidReading",
           "format": "Compact",
           "source": "byText"
@@ -109,7 +112,8 @@ the validation should be performed, including:
     "stream": {
       "server": "localhost",
       "port": 9092,
-      "topic": "rdf"
+      "topic": "rdf",
+      "groupId": "myGroup"
     }
   }
 }

--- a/modules/server/src/main/resources/logback.xml
+++ b/modules/server/src/main/resources/logback.xml
@@ -87,6 +87,8 @@
     <!--  ............................................  -->
     <!--  LOGGERS AND ASSOCIATED APPENDERS  -->
 
+    <!-- Silence Kafka's abusive logs while attempting to connect -->
+    <logger name="org.apache.kafka" level="OFF"/>
     <!-- 
     Root logger:
     - Show console messages

--- a/modules/server/src/main/scala/es/weso/rdfshape/server/api/routes/data/logic/DataSource.scala
+++ b/modules/server/src/main/scala/es/weso/rdfshape/server/api/routes/data/logic/DataSource.scala
@@ -14,7 +14,7 @@ private[api] object DataSource extends MyEnum[String] {
   val FILE     = "byFile"
   val COMPOUND = "byCompound"
 
-  val values =
+  val values: Set[DataSource] =
     Set(TEXT, URL, FILE, COMPOUND)
   val default: DataSource = TEXT
 }

--- a/modules/server/src/main/scala/es/weso/rdfshape/server/api/routes/data/logic/operations/DataExtract.scala
+++ b/modules/server/src/main/scala/es/weso/rdfshape/server/api/routes/data/logic/operations/DataExtract.scala
@@ -13,6 +13,10 @@ import es.weso.rdfshape.server.api.routes.data.logic.operations.DataExtract.{
   successMessage
 }
 import es.weso.rdfshape.server.api.routes.data.logic.types.Data
+import es.weso.rdfshape.server.api.utils.parameters.IncomingRequestParameters.{
+  SchemaParameter,
+  ShapeMapParameter
+}
 import es.weso.schema.Schema
 import es.weso.schemaInfer.{InferOptions, PossiblePrefixes, SchemaInfer}
 import es.weso.shapemaps.{NodeSelector, ResultShapeMap}
@@ -76,14 +80,17 @@ private[api] object DataExtract extends LazyLogging {
       Json.fromFields(
         List(
           (
-            "schema",
+            SchemaParameter.name,
             Json.fromString(
               dataExtract.schema
                 .serialize(dataExtract.targetSchemaFormat.name)
                 .unsafeRunSync()
             )
           ),
-          ("shapeMap", Json.fromString(dataExtract.shapeMap.toString))
+          (
+            ShapeMapParameter.name,
+            Json.fromString(dataExtract.shapeMap.toString)
+          )
         )
       )
 

--- a/modules/server/src/main/scala/es/weso/rdfshape/server/api/routes/endpoint/logic/query/SparqlQuerySource.scala
+++ b/modules/server/src/main/scala/es/weso/rdfshape/server/api/routes/endpoint/logic/query/SparqlQuerySource.scala
@@ -14,6 +14,6 @@ private[api] object SparqlQuerySource extends MyEnum[String] {
   val URL  = "byUrl"
   val FILE = "byFile"
 
-  val values                     = Set(TEXT, URL, FILE)
-  val default: SparqlQuerySource = TEXT
+  val values: Set[SparqlQuerySource] = Set(TEXT, URL, FILE)
+  val default: SparqlQuerySource     = TEXT
 }

--- a/modules/server/src/main/scala/es/weso/rdfshape/server/api/routes/schema/logic/operations/stream/transformations/CometTransformations.scala
+++ b/modules/server/src/main/scala/es/weso/rdfshape/server/api/routes/schema/logic/operations/stream/transformations/CometTransformations.scala
@@ -49,7 +49,7 @@ private[schema] object CometTransformations extends LazyLogging {
   /** Time that the server will wait without receiving any items for the input
     * stream before raising a [[StreamTimeoutException]]
     */
-  private lazy val timeout = 1.5 minutes
+  private lazy val timeout = 1 minute
 
   /** Stream transformation pipe:
     * 1. Use the configuration to a stream validation operation as input

--- a/modules/server/src/main/scala/es/weso/rdfshape/server/api/routes/schema/logic/trigger/TriggerShapeMap.scala
+++ b/modules/server/src/main/scala/es/weso/rdfshape/server/api/routes/schema/logic/trigger/TriggerShapeMap.scala
@@ -9,7 +9,12 @@ import es.weso.rdfshape.server.api.routes.data.logic.types.Data
 import es.weso.rdfshape.server.api.routes.schema.logic.trigger.TriggerModeType.TriggerModeType
 import es.weso.rdfshape.server.api.routes.schema.logic.types.Schema
 import es.weso.rdfshape.server.api.routes.shapemap.logic.ShapeMap
-import es.weso.rdfshape.server.api.utils.parameters.IncomingRequestParameters.ShapeMapParameter
+import es.weso.rdfshape.server.api.utils.parameters.IncomingRequestParameters.{
+  DataParameter,
+  SchemaParameter,
+  ShapeMapParameter,
+  TypeParameter
+}
 import es.weso.schema.{ShapeMapTrigger, ValidationTrigger}
 import es.weso.shapemaps.{ShapeMap => ShapeMapW}
 import io.circe._
@@ -107,9 +112,9 @@ private[api] object TriggerShapeMap
   override implicit val encode: Encoder[TriggerShapeMap] =
     (tsm: TriggerShapeMap) =>
       Json.obj(
-        ("type", tsm.`type`.asJson),
-        ("shapeMap", tsm.shapeMap.asJson),
-        ("data", tsm.data.asJson),
-        ("schema", tsm.schema.asJson)
+        (TypeParameter.name, tsm.`type`.asJson),
+        (ShapeMapParameter.name, tsm.shapeMap.asJson),
+        (DataParameter.name, tsm.data.asJson),
+        (SchemaParameter.name, tsm.schema.asJson)
       )
 }

--- a/modules/server/src/main/scala/es/weso/rdfshape/server/api/routes/schema/service/SchemaService.scala
+++ b/modules/server/src/main/scala/es/weso/rdfshape/server/api/routes/schema/service/SchemaService.scala
@@ -253,8 +253,8 @@ private object SchemaServiceDescriptions {
   }
 
   case object SchemaType {
-    val schemaTypes = List("ShEx", "SHACL")
-    val name        = "SchemaType"
+    val schemaTypes: List[String] = List("ShEx", "SHACL")
+    val name                      = "SchemaType"
     val description =
       s"Type of the validation schema. One of: ${schemaTypes.mkString(", ")}"
   }

--- a/modules/server/src/main/scala/es/weso/rdfshape/server/api/routes/shapemap/logic/ShapeMapSource.scala
+++ b/modules/server/src/main/scala/es/weso/rdfshape/server/api/routes/shapemap/logic/ShapeMapSource.scala
@@ -14,6 +14,6 @@ private[api] object ShapeMapSource extends MyEnum[String] {
   val URL  = "byUrl"
   val FILE = "byFile"
 
-  val values                  = Set(TEXT, URL, FILE)
-  val default: ShapeMapSource = TEXT
+  val values: Set[ShapeMapSource] = Set(TEXT, URL, FILE)
+  val default: ShapeMapSource     = TEXT
 }

--- a/modules/server/src/main/scala/es/weso/rdfshape/server/api/routes/shapemap/logic/operations/ShapeMapInfo.scala
+++ b/modules/server/src/main/scala/es/weso/rdfshape/server/api/routes/shapemap/logic/operations/ShapeMapInfo.scala
@@ -5,6 +5,7 @@ import com.typesafe.scalalogging.LazyLogging
 import es.weso.rdf.PrefixMap
 import es.weso.rdfshape.server.api.routes.shapemap.logic.ShapeMap
 import es.weso.rdfshape.server.api.routes.shapemap.logic.operations.ShapeMapInfo.ShapeMapInfoResult
+import es.weso.rdfshape.server.api.utils.parameters.IncomingRequestParameters.ShapeMapParameter
 import es.weso.rdfshape.server.utils.json.JsonUtils.prefixMap2JsonArray
 import es.weso.shapemaps.{ShapeMap => ShapeMapW}
 import io.circe.syntax.EncoderOps
@@ -97,7 +98,7 @@ private[api] object ShapeMapInfo extends LazyLogging {
       Json.fromFields(
         List(
           ("message", Json.fromString(shapeMapInfo.successMessage)),
-          ("shapeMap", shapeMapInfo.inputShapeMap.asJson),
+          (ShapeMapParameter.name, shapeMapInfo.inputShapeMap.asJson),
           ("result", shapeMapInfo.result.asJson)
         )
       )

--- a/modules/server/src/main/scala/es/weso/rdfshape/server/api/routes/wikibase/logic/operations/WikibaseOperationFormats.scala
+++ b/modules/server/src/main/scala/es/weso/rdfshape/server/api/routes/wikibase/logic/operations/WikibaseOperationFormats.scala
@@ -15,6 +15,6 @@ private[api] object WikibaseOperationFormats extends MyEnum[String] {
   val XML     = "xml"
   val XML_FM  = "xmlfm"
 
-  val values                            = Set(JSON, JSON_FM, XML, XML_FM)
-  val default: WikibaseOperationFormats = JSON
+  val values: Set[WikibaseOperationFormats] = Set(JSON, JSON_FM, XML, XML_FM)
+  val default: WikibaseOperationFormats     = JSON
 }

--- a/modules/server/src/main/scala/es/weso/rdfshape/server/api/routes/wikibase/logic/operations/search/WikibaseSearchTypes.scala
+++ b/modules/server/src/main/scala/es/weso/rdfshape/server/api/routes/wikibase/logic/operations/search/WikibaseSearchTypes.scala
@@ -19,7 +19,9 @@ private[api] object WikibaseSearchTypes extends MyEnum[String] {
   val SENSE    = "sense"
   val SCHEMA   = "schema"
 
-  val values                       = Set(ENTITY, PROPERTY, LEXEME, FORM, SENSE)
-  val basicValues                  = Set(ENTITY, PROPERTY, LEXEME, SCHEMA)
+  val values: Set[WikibaseSearchTypes] =
+    Set(ENTITY, PROPERTY, LEXEME, FORM, SENSE)
+  val basicValues: Set[WikibaseSearchTypes] =
+    Set(ENTITY, PROPERTY, LEXEME, SCHEMA)
   val default: WikibaseSearchTypes = ENTITY
 }

--- a/modules/server/src/main/scala/es/weso/rdfshape/server/api/swagger/package.scala
+++ b/modules/server/src/main/scala/es/weso/rdfshape/server/api/swagger/package.scala
@@ -48,6 +48,16 @@ import java.net.URL
 import scala.reflect.runtime.universe
 import scala.reflect.runtime.universe.typeOf
 
+/** @note For the streaming validations endpoint, remember to add some responses
+  *       information manually into the generated swagger-file, e.g.:
+  *       responses:
+  *        '200':
+  *          description: Dummy response, a WebSockets connection should start
+  *        '400':
+  *          description: A non-WebSockets request was received
+  *        '500':
+  *          description: Handshake failed
+  */
 package object swagger {
   // Import all models
 

--- a/modules/server/src/main/scala/es/weso/rdfshape/server/api/utils/parameters/IncomingRequestParameters.scala
+++ b/modules/server/src/main/scala/es/weso/rdfshape/server/api/utils/parameters/IncomingRequestParameters.scala
@@ -28,7 +28,7 @@ object IncomingRequestParameters {
   lazy val node         = "node"
   lazy val nodeSelector = "nodeSelector"
 
-  lazy val shapeMap       = "shapeMap"
+  lazy val shapeMap       = "shape-map"
   lazy val shapeMapFormat = "shapeMapFormat"
 
   lazy val query = "query"

--- a/modules/server/src/main/scala/es/weso/rdfshape/server/html2rdf/HtmlToRdf.scala
+++ b/modules/server/src/main/scala/es/weso/rdfshape/server/html2rdf/HtmlToRdf.scala
@@ -33,7 +33,7 @@ object HtmlToRdf extends LazyLogging {
 
   /** List of all available RDF data extractors
     */
-  val availableExtractors =
+  val availableExtractors: List[Extractor] =
     List(RDFA11, Microdata)
 
   /** List of the names of all available RDF data extractors

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.2.10"
+ThisBuild / version := "0.2.11"


### PR DESCRIPTION
End the task begun by #309 and #310, plus included minor changes as requested:
- Reduced the timeout after which the server decides that waiting for streaming data is not worth.
- Changed API parameter name for _ShapeMaps_ from `shapeMap` to `shape-map`.
- Filtered out the underlying Apache Kafka logs, which grew way more than expected, harming our file-stored logs.

Also, updating to `0.2.11`.